### PR TITLE
Minecraft <=1.17 support. Still requires java 17 though

### DIFF
--- a/src/main/java/archives/tater/mixinblacklist/MixinBlacklist.java
+++ b/src/main/java/archives/tater/mixinblacklist/MixinBlacklist.java
@@ -6,8 +6,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import net.fabricmc.loader.api.FabricLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -23,7 +23,7 @@ public class MixinBlacklist {
     // This logger is used to write text to the console and the log file.
     // It is considered best practice to use your mod id as the logger's name.
     // That way, it's clear which mod wrote info, warnings, and errors.
-    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
 
     public static final Path CONFIG_PATH =
             FabricLoader.getInstance().getConfigDir().resolve(MOD_ID + ".json");

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,6 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.14",
-		"minecraft": ">=1.18",
 		"java": ">=17"
 	},
 	"suggests": {


### PR DESCRIPTION
This PR replaces slf4j logger with the log4j one to make this work with older minecraft versions (tested on 1.16.5 but I'm sure that will work with legacy fabric as well)